### PR TITLE
Change DWD OpenData url from HTTPS to HTTP.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="simple_dwd_weatherforecast",
-    version="1.1.2",
+    version="1.1.3",
     author="Max Fermor",
     description="A simple tool to retrieve a weather forecast from DWD OpenData",
     long_description=long_description,

--- a/simple_dwd_weatherforecast/dwdforecast.py
+++ b/simple_dwd_weatherforecast/dwdforecast.py
@@ -81,7 +81,7 @@ class Weather:
 
     namespaces = {
         "kml": "http://www.opengis.net/kml/2.2",
-        "dwd": "https://opendata.dwd.de/weather/lib/pointforecast_dwd_extension_V1_0.xsd",
+        "dwd": "http://opendata.dwd.de/weather/lib/pointforecast_dwd_extension_V1_0.xsd",
     }
 
     weather_codes = {

--- a/simple_dwd_weatherforecast/dwdforecast.py
+++ b/simple_dwd_weatherforecast/dwdforecast.py
@@ -603,7 +603,7 @@ def download_weather_report(region_code):
 
 
 def download_latest_kml(stationid):
-    url = f"https://opendata.dwd.de/weather/local_forecasts/mos/MOSMIX_L/single_stations/{stationid}/kml/MOSMIX_L_LATEST_{stationid}.kmz"
+    url = f"http://opendata.dwd.de/weather/local_forecasts/mos/MOSMIX_L/single_stations/{stationid}/kml/MOSMIX_L_LATEST_{stationid}.kmz"
     request = requests.get(url)
     file = BytesIO(request.content)
     kmz = ZipFile(file, "r")


### PR DESCRIPTION
The DWD seems to have missed to update their SSL certificate for https://opendata.dwd.de/ (08.05.2022 17:27).
The certificate expired at 08.05.2022.

It seems all the requests done by this package contain no data (all GET). So using an unencrypted connection should do no harm. DWD OpenData is completely usable with HTTP.

best regards,
SpiGAndromeda